### PR TITLE
Implemented file search different way

### DIFF
--- a/bin/commonjs-findpkgs.js
+++ b/bin/commonjs-findpkgs.js
@@ -17,13 +17,6 @@ if (process.argv[2] == '--ignore') {
 var dir = process.argv[2];
 if (!dir) dir = '.';
 
-// make ignores relative to dir
-if (ignores) {
-  for (var i = 0; i < ignores.length; i++) {
-    ignores[i] = path.join(dir, ignores[i]);
-  }
-}
-
 findpkgs(dir, ignores, function(err, pkgs) {
   if (err) {
     console.error(err);

--- a/findpkgs.js
+++ b/findpkgs.js
@@ -1,27 +1,19 @@
-var glob = require('glob');
 var path = require('path').posix;
 var fs = require('fs');
 var readJson = require('read-package-json');
+var findfiles = require('find-files-excluding-dirs');
 
 // findpkgs finds CommonJS packages in dir, ignoring paths in ignores. The
 // callback is called as cb(err, pkgs), where pkgs is an array of objects
 // describing the packages that were found.
-module.exports = function(dir, ignores, cb) {
-  glob(path.join(dir, '**/package.json'), function(err, files) {
-    if (err) {
-      return cb(err);
-    }
-
-    // check that files are not ignored
-    files = files.filter(function(file) {
-      if (ignores) {
-        for (var i = 0; i < ignores.length; i++) {
-          if (file.indexOf(ignores[i]) == 0) return false; // skip processing file
-        }
+module.exports = function(dir, exclude, cb) {
+  try {
+    var files = findfiles(dir, {
+      exclude: exclude,
+      matcher: function(directory, file) {
+        return file == 'package.json';
       }
-      return true;
     });
-
     if (!files.length) {
         return cb(null, []);
     }
@@ -31,24 +23,31 @@ module.exports = function(dir, ignores, cb) {
       readJson(file, function(err, data) {
         var pkgdir = path.dirname(file);
 
-        var libFiles = glob.sync(path.join(pkgdir, 'lib/**/*.js'));
+        var libFiles = findfiles(path.join(pkgdir, 'lib'), {
+          matcher: jsmatcher
+        });
         if (!err) {
           var mainFile = findMainFile(pkgdir, data.main || 'index');
           if (mainFile && libFiles.indexOf(mainFile) == -1) libFiles.push(mainFile);
         }
 
+        var testFiles = findfiles(path.join(pkgdir, 'test'), {
+          matcher: jsmatcher
+        });
         pkgs.push({
           dir: pkgdir,
           packageJSONFile: file,
           package: data,
           error: err || undefined,
           libFiles: libFiles,
-          testFiles: glob.sync(path.join(pkgdir, 'test/**/*.js')),
+          testFiles: testFiles,
         });
         if (pkgs.length == files.length) cb(null, pkgs);
       });
     });
-  });
+  } catch (e) {
+    cb(e);
+  }
 };
 
 function findMainFile(dir, main) {
@@ -59,4 +58,8 @@ function findMainFile(dir, main) {
     if (fs.existsSync(path.join(dir, f))) found = f;
   });
   if (found) return path.join(dir, found);
+}
+
+function jsmatcher(directory, file) {
+	return /\.js$/.test(file);
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "main": "findpkgs.js",
   "dependencies": {
     "read-package-json": "2.0.4",
-    "glob": "~3.2.9"
+    "find-files-excluding-dirs": "alexsaveliev/find-files-excluding-dirs"
   },
   "devDependencies": {
     "mocha": "2.5.3",

--- a/test.js
+++ b/test.js
@@ -7,7 +7,7 @@ describe('commonjs-findpkgs', function() {
     {name: 'b'},
     {name: 'c'},
     {name: 'multi'},
-    {name: 'ignore', args: ['--ignore', '["./package.json", "./subdir"]']},
+    {name: 'ignore', args: ['--ignore', '["subdir"]']},
     {name: 'syntax_error'},
   ].filter(function(test) { return new RegExp(process.env['F'] || '').test(test.name); }).forEach(function(test) {
     it(test.name, function(done) {

--- a/testdata/ignore/pkgs.json
+++ b/testdata/ignore/pkgs.json
@@ -1,5 +1,15 @@
 [
   {
+    "dir": "testdata/ignore",
+    "packageJSONFile": "testdata/ignore/package.json",
+    "error": {
+      "code": "EJSONPARSE",
+      "file": "testdata/ignore/package.json"
+    },
+    "libFiles": [],
+    "testFiles": []
+  },
+  {
     "dir": "testdata/ignore/not-ignored",
     "packageJSONFile": "testdata/ignore/not-ignored/package.json",
     "libFiles": [],


### PR DESCRIPTION
instead of using `glob` and then filtering the results recursively, traversing file tree starting from given root excluding specific files/directories. This makes impossible "find all packages in a given directory except one located directly in sub-directory A (however package in A/B still counts)" but improves performance when we need to exclude huge directories such as "node_modules" because it will be completely excluded from search.
